### PR TITLE
push data generated in python process & init numpy once

### DIFF
--- a/bin/setup.py
+++ b/bin/setup.py
@@ -1,15 +1,63 @@
 import libPyCpp
 import numpy as np
-def client(i, read, info, dStruc):
-    s = libPyCpp.kvs_client(i, read, info, dStruc)
-    print(s)
-    if dStruc == 1 and s!=None:
-        print("explicitly")
-        a = libPyCpp.kvs_free(s)
 
+def put_npArray(id, keyInfo):
+    shmArray = libPyCpp.kvs_ShmPtr_npArray(keyInfo)
+    shmArray[0:int(keyInfo)] = 25
+    libPyCpp.kvs_Put(id, keyInfo)
     return
-client(1, 0, "30", 0)
-client(1, 1, "30", 0)
-client(1, 0, "50", 1)
-client(1, 1, "50", 1)
-print("client finished")
+
+def get_npArray(id, keyInfo):
+    s = libPyCpp.kvs_GetNp(id, keyInfo)
+    return s
+
+def put_BtArray(id, keyInfo):
+    shmArray = libPyCpp.kvs_ShmPtr_btArray(keyInfo)
+    for i in range(int(keyInfo)):
+        shmArray[i] = 0x03
+    libPyCpp.kvs_Put(id, keyInfo)
+    a = libPyCpp.kvs_free(shmArray)
+    return
+
+def get_BtArray(id, keyInfo):
+    s = libPyCpp.kvs_GetBt(id, keyInfo)
+    return s
+
+"""
+put function:
+    id: client identity
+    keyInfo: key information
+    dStruc: whay is the value type -- 1: bytearray 0: numpy array
+"""
+def put(id, keyInfo, dataStruc):
+    if (dataStruc == 0):
+        return put_npArray(id, keyInfo)
+    if (dataStruc == 1):
+        return put_BtArray(id, keyInfo)
+
+"""
+get function:
+    id: client identity
+    keyInfo: key information
+    dStruc: whay is the value type -- 1: bytearray 0: numpy array
+"""
+def get(id, keyInfo, dataStruc):
+    if (dataStruc == 0):
+        return get_npArray(id, keyInfo)
+    if (dataStruc == 1):
+        return get_BtArray(id, keyInfo)
+
+
+
+put(1, "256", 0)
+rs = get(1, "256", 0)
+put(1, "1024", 1)
+rs2 = get(1, "1024", 1)
+
+
+"""
+require explicitly free bytearray object. 
+"""
+a = libPyCpp.kvs_free(rs2)
+
+

--- a/demo/PyCpp/Client.cpp
+++ b/demo/PyCpp/Client.cpp
@@ -12,53 +12,191 @@
 #include "util.h"
 #include <numpy/arrayobject.h>
 
+
 using string = std::string;
-
-
 using namespace ipc::shm;
 
 namespace ipc {
 
-constexpr char const name__  [] = "ipc-kvs";
-
-capo::random<> rand__{
-    static_cast<int>(1),
-    static_cast<int>(127)
-};
-
-ipc::channel shared_chan { name__, ipc::sender | ipc::receiver };
-
-std::atomic<bool> is_quit__{ false };
-
-void * kvs_client(char id, bool is_read, string info, int *finalSize, int dataStruc) {
-    auto exit = [](int) {
-        is_quit__.store(true, std::memory_order_release);
-        shared_chan.disconnect();
+    capo::random<> rand__{
+        static_cast<int>(1),
+        static_cast<int>(127)
     };
-    ::signal(SIGINT  , exit);
-    ::signal(SIGABRT , exit);
-    ::signal(SIGSEGV , exit);
-    ::signal(SIGTERM , exit);
-    ::signal(SIGHUP  , exit);
-    
-    auto client_id = 2 + id;
-    std::cout << "Launching client " << client_id << " ...\n";
+    std::atomic<bool> is_quit__{ false };
+    constexpr char const name__  [] = "ipc-kvs";
+    ipc::channel shared_chan { name__, ipc::sender | ipc::receiver };
 
-    auto start_stamp = std::chrono::system_clock::now();
-    string req;
-    auto req_id = rand__();
-    string key_name = "a" + info;
-    
-    // request addres (1 byte) | resp address (1 byte) | get/put (1 byte) | request id (1 byte) | metadata len (1 byte)| metadata | optional value
-    req.push_back(1);
-    req.push_back(client_id);
-    if (is_read){
+    PyObject *
+    PyArray_FromIntArray(int *rind, Py_ssize_t size) {
+        npy_intp dim[1] = {size};
+        PyArrayObject *mat = (PyArrayObject*) PyArray_SimpleNewFromData(1, dim, NPY_INT, (char*) rind);
+        return PyArray_Return(mat);
+    }
+
+    PyObject * WrappGetNp(PyObject* self, PyObject *args) {
+        int id;
+        const char * info_;
+        int finalSize = 0; // dataStruc: 1 represent bytearray; 0 represent numpy array
+        
+        if(!PyArg_ParseTuple(args, "iz", &id, &info_)){
+            return NULL;
+        }
+        string info(info_);
+        auto client_id = 2 + id;
+        std::cout << "Launching client " << client_id << " ...\n";
+        string req;
+        auto req_id = rand__();
+        string key_name = "a" + info;
+        req.push_back(1);
+        req.push_back(client_id);
         req.push_back(1);
         req.push_back(req_id);
         req.push_back((char) key_name.size());
         req += key_name;
+        while (!shared_chan.send(req)) {
+            // waiting for connection
+            shared_chan.wait_for_recv(2);
+        }
+        auto dd = shared_chan.recv();
+        auto str = static_cast<char*>(dd.data());
+        
+        // response address (1 byte) | request id (1 byte) | is_success (1 byte) | optional value
+        if (str == nullptr) {
+            std::cout << "Ack error" << std::endl;
+            return Py_None;
+        }
+        if (client_id != (int) str[0]){
+            std::cout << "Not my ack" << std::endl;
+            return Py_None;
+        }  
+        if (str[1] != req_id) {
+            std::cout << "request id doesn't match" << std::endl;
+            return Py_None;
+        }
+        auto size_len = stoi(string(str + 3));
+        auto shm_id = acquire(key_name.c_str(), size_len, open);
+        auto shm_ptr = (int *) get_mem(shm_id, nullptr);
+        auto val_size = strlen((char *) shm_ptr);
+        std::cout << "----Receive Get" << std::endl;
+        auto start_stamp = std::chrono::system_clock::now();
+        auto mat = PyArray_FromIntArray(shm_ptr, size_len - 1);
+        auto trans_stamp = std::chrono::system_clock::now();
+        auto trans_time = std::chrono::duration_cast<std::chrono::microseconds>(trans_stamp - start_stamp).count();
+        std::cout << "transfer from int * to numpy array using " << trans_time << " ms\n";
+        return mat;
     }
-    else {
+
+    PyObject * WrappGetBt(PyObject* self, PyObject *args) {
+        int id;
+        const char * info_;
+        
+        if(!PyArg_ParseTuple(args, "iz", &id, &info_)){
+            return NULL;
+        }
+        string info(info_);
+        auto client_id = 2 + id;
+        std::cout << "Launching client " << client_id << " ...\n";
+        string req;
+        auto req_id = rand__();
+        string key_name = "a" + info;
+        req.push_back(1);
+        req.push_back(client_id);
+        req.push_back(1);
+        req.push_back(req_id);
+        req.push_back((char) key_name.size());
+        req += key_name;
+        while (!shared_chan.send(req)) {
+            // waiting for connection
+            shared_chan.wait_for_recv(2);
+        }
+        auto dd = shared_chan.recv();
+        auto str = static_cast<char*>(dd.data());
+        
+        // response address (1 byte) | request id (1 byte) | is_success (1 byte) | optional value
+        if (str == nullptr) {
+            std::cout << "Ack error" << std::endl;
+            return Py_None;
+        }
+        if (client_id != (int) str[0]){
+            std::cout << "Not my ack" << std::endl;
+            return Py_None;
+        }  
+        if (str[1] != req_id) {
+            std::cout << "request id doesn't match" << std::endl;
+            return Py_None;
+        }
+        auto size_len = stoi(string(str + 3));
+        auto shm_id = acquire(key_name.c_str(), size_len, open);
+        auto shm_ptr = (char *) get_mem(shm_id, nullptr);
+        auto val_size = strlen((char *) shm_ptr);
+
+        std::cout << "----Receive Get" << std::endl;
+
+        auto start_stamp = std::chrono::system_clock::now();
+        auto bArray = PyByteArray_FromString_WithoutCopy(shm_ptr, size_len - 1);
+        auto trans_stamp = std::chrono::system_clock::now();
+        auto trans_time = std::chrono::duration_cast<std::chrono::microseconds>(trans_stamp - start_stamp).count();
+        std::cout << "transfer from char * to python bytearray using " << trans_time << " ms\n";
+        
+        return bArray;
+    }
+
+    PyObject* WrappFree(PyObject* self, PyObject *args)
+    {
+        PyByteArrayObject * toFree  = (PyByteArrayObject *) PyTuple_GET_ITEM(args, 0);
+        toFree->ob_bytes = NULL;
+        return Py_None;
+    }
+
+    PyObject* WrappShmNp(PyObject* self, PyObject *args)
+    {
+        const char * info_;
+        
+        if(!PyArg_ParseTuple(args, "z", &info_)){
+            return NULL;
+        }
+        string info(info_);
+        string key_name = "a" + info;
+        std::size_t shm_size = stoi(info) + 1;
+        auto shm_id = acquire(key_name.c_str(), shm_size);
+        int * shm_ptr = (int *) get_mem(shm_id, nullptr);
+        auto mat = PyArray_FromIntArray(shm_ptr, shm_size - 1);
+        return mat;
+    }
+
+    PyObject* WrappShmBt(PyObject* self, PyObject *args)
+    {
+        const char * info_;
+        
+        if(!PyArg_ParseTuple(args, "z", &info_)){
+            return NULL;
+        }
+        string info(info_);
+        string key_name = "a" + info;
+        std::size_t shm_size = stoi(info) + 1;
+        auto shm_id = acquire(key_name.c_str(), shm_size);
+        auto shm_ptr = (char *) get_mem(shm_id, nullptr);
+        auto shm_id_ = acquire(key_name.c_str(), shm_size, open);
+        auto shm_ptr_ = (char *) get_mem(shm_id_, nullptr);
+        auto bArray = PyByteArray_FromString_WithoutCopy(shm_ptr_, shm_size - 1);
+        
+        return bArray;
+    }
+
+    PyObject* WrappPut(PyObject* self, PyObject *args)
+    {
+        int id;
+        const char *info_;
+        if(!PyArg_ParseTuple(args, "iz", &id, &info_)){
+            return NULL;
+        }
+        int client_id = 2 + id;
+        std::cout << "Launching client " << client_id << " ...\n";
+        string info(info_);
+        string req, key_name = "a" + info;
+        auto req_id = rand__();
+        req.push_back(1);
+        req.push_back(client_id);
         req.push_back(2);
         req.push_back(req_id);
         req.push_back((char) key_name.size());
@@ -66,142 +204,57 @@ void * kvs_client(char id, bool is_read, string info, int *finalSize, int dataSt
         std::size_t shm_size = stoi(info) + 1;
         req += std::to_string(shm_size);
         int data_len = stoi(info);
-        if(dataStruc == 0) {
-            auto shm_id = acquire(key_name.c_str(), shm_size);
-            int * shm_ptr = (int *) get_mem(shm_id, nullptr);
-            for (int i = 0; i < shm_size; i++) shm_ptr[i] = i;
+        while (!shared_chan.send(req)) {
+            // waiting for connection
+            shared_chan.wait_for_recv(2);
         }
-        else {
-            auto shm_id = acquire(key_name.c_str(), shm_size);
-            auto shm_ptr = (char *) get_mem(shm_id, nullptr);
-            memset(shm_ptr, '1', data_len);
-            shm_ptr[data_len] = '\0';
+        auto dd = shared_chan.recv();
+        auto str = static_cast<char*>(dd.data());
+
+        // response address (1 byte) | request id (1 byte) | is_success (1 byte) | optional value
+        if (str == nullptr) {
+            std::cout << "Ack error" << std::endl;
+            return Py_None;
         }
-    }
-
-    auto ready_stamp = std::chrono::system_clock::now();
-
-    while (!shared_chan.send(req)) {
-        // waiting for connection
-        shared_chan.wait_for_recv(2);
-    }
-
-    // recv ack
-    auto dd = shared_chan.recv();
-    auto str = static_cast<char*>(dd.data());
-
-    // response address (1 byte) | request id (1 byte) | is_success (1 byte) | optional value
-    if (str == nullptr) {
-        char *err = "Ack error";
-        std::cout << err << std::endl;
-        return NULL;
-    }
-    if (client_id != (int) str[0]){
-        char * err = "Not my ack";
-        std::cout << err << std::endl;
-        return NULL;
-    }  
-    if (str[1] != req_id) {
-        char * err = "request id doesn't match";
-        std::cout << err << std::endl;
-        return NULL;
-    }
-    auto ack_stamp = std::chrono::system_clock::now();
-
-        
-    if (is_read){
-        auto size_len = stoi(string(str + 3));
-        auto shm_id = acquire(key_name.c_str(), size_len, open);
-        if (dataStruc == 0) {
-            auto shm_ptr = (int *) get_mem(shm_id, nullptr);
-            * finalSize = size_len;
-            return shm_ptr;
-        } else {
-            auto shm_ptr = (char *) get_mem(shm_id, nullptr);
-
-            auto ptr_stamp = std::chrono::system_clock::now();
-
-            auto val_size = strlen(shm_ptr);
-            auto val_stamp = std::chrono::system_clock::now();
-
-            auto ready_time = std::chrono::duration_cast<std::chrono::microseconds>(ready_stamp - start_stamp).count();
-            auto ack_time = std::chrono::duration_cast<std::chrono::microseconds>(ack_stamp - ready_stamp).count();
-            auto ptr_time = std::chrono::duration_cast<std::chrono::microseconds>(ptr_stamp - ack_stamp).count();
-            auto val_time = std::chrono::duration_cast<std::chrono::microseconds>(val_stamp - ptr_stamp).count();
-
-            std::cout << "Receive Get " << key_name << ", val_size: " << val_size
-                                                    << ", shm_size: " << size_len
-                                                    << ", ready_time: " << ready_time
-                                                    << ", ack_time: " << ack_time
-                                                    << ", ptr_time: " << ptr_time
-                                                    << ", val_time: " << val_time
-                                                    <<"\n";
-            * finalSize = size_len;
-            return shm_ptr;
+        if (client_id != (int) str[0]){
+            std::cout << "Not my ack" << std::endl;
+            return Py_None;
+        }  
+        if (str[1] != req_id) {
+            std::cout << "request id doesn't match" << std::endl;
+            return Py_None;
         }
-    } else {
-        auto ready_time = std::chrono::duration_cast<std::chrono::microseconds>(ready_stamp - start_stamp).count();
-        auto ack_time = std::chrono::duration_cast<std::chrono::microseconds>(ack_stamp - ready_stamp).count();
-
-        std::cout << "Receive Put " << key_name << ", ready_time "<< ready_time 
-                                                << ", ack_time: " << ack_time 
-                                                <<"\n";
-        char * put_Msg = "Receive Put";
-        std::cout << put_Msg << std::endl;
-        return NULL;
+        std::cout << "----Receive Put" << std::endl;
+        return Py_None;
+            
     }
-}
 
-PyObject* WrappClient(PyObject* self, PyObject *args)
-{
-    int id, is_read;
-    const char * info;
-    int dataStruc = 0; // 1 represent bytearray; 0 represent numpy array
-    
-    if(!PyArg_ParseTuple(args, "iizi", &id, &is_read, &info, &dataStruc)){
-        return NULL;
-    }
-    int finalSize = 0;
-    void * resp = kvs_client(id, is_read, info, &finalSize, dataStruc);
-    if (resp == NULL) return Py_None;
-    if (dataStruc == 0) {
-        int * resp_ = (int *) resp;
-        return PyArray_FromIntArray(resp_, finalSize);
-    } else {
-        char * resp_ = (char *) resp;
-        return PyByteArray_FromString_WithoutCopy(resp_, finalSize);
+
+    static PyMethodDef client_methods[] = {
+    {"kvs_free", WrappFree, METH_VARARGS},
+    {"kvs_ShmPtr_npArray", WrappShmNp, METH_VARARGS},
+    {"kvs_Put", WrappPut, METH_VARARGS},
+    {"kvs_GetNp", WrappGetNp, METH_VARARGS},
+    {"kvs_ShmPtr_btArray", WrappShmBt, METH_VARARGS},
+    {"kvs_GetBt", WrappGetBt, METH_VARARGS},
+    {NULL, NULL}
+    };
+
+    static struct PyModuleDef client_module = {
+            PyModuleDef_HEAD_INIT,
+            "test",
+            NULL,
+            -1,
+            client_methods
+    };
+
+    PyMODINIT_FUNC PyInit_libPyCpp()
+    {
+        import_array(); // init numpy module when loading lib
+        return PyModule_Create(&client_module);
     }
 
 }
 
-PyObject* WrappFree(PyObject* self, PyObject *args)
-{
-    PyByteArrayObject * toFree  = (PyByteArrayObject *) PyTuple_GET_ITEM(args, 0);
-    toFree->ob_bytes = NULL;
-
-    return Py_None;
-
-}
-
-static PyMethodDef client_methods[] = {
- {"kvs_client", WrappClient, METH_VARARGS, "something"},
- {"kvs_free", WrappFree, METH_VARARGS},
- {NULL, NULL}
-};
-
-static struct PyModuleDef client_module = {
-        PyModuleDef_HEAD_INIT,
-        "test",
-        NULL,
-        -1,
-        client_methods
-};
-
-PyMODINIT_FUNC PyInit_libPyCpp()
-{
-     return PyModule_Create(&client_module);
-}
-
-}
 
 

--- a/demo/PyCpp/util.cpp
+++ b/demo/PyCpp/util.cpp
@@ -1,5 +1,6 @@
 #include "util.h"
 #include <iostream>
+#include <chrono>
 #include <numpy/arrayobject.h>
 namespace ipc {
         
@@ -39,14 +40,8 @@ namespace ipc {
         return (PyObject *)arrayObject;
     }
 
-    PyObject *
-    PyArray_FromIntArray(int *rind, Py_ssize_t size) {
-        import_array();
-        npy_intp dim[1];
-        dim[0] = size;
-        PyArrayObject *mat = (PyArrayObject*) PyArray_SimpleNewFromData(1, dim, NPY_INT, (char*) rind);
-        return PyArray_Return(mat);
-    }
+
 
 }
+
 


### PR DESCRIPTION
As the title.

1. call import_array when initializing the module rather than every time calling get.
2. generate push data in python process rather than in c++ process.
3. 1kb data transfer from int array to numpy array costs 3-4ms.
4. 1kb data transfer from char array to python byte array costs 1ms.

TODO: optimization