### PR TITLE
reconnect and disconnect  once and error return

### DIFF
--- a/bin/setup.py
+++ b/bin/setup.py
@@ -10,19 +10,54 @@ def put_npArray(id, keyInfo):
 
 def get_npArray(id, keyInfo):
     s = libPyCpp.kvs_GetNp(id, keyInfo)
-    return s
+    # if s is an int, it means there is an error
+    if isinstance(s,int):
+        if status == 1:
+            print("Ack error")
+        if status == 2:
+            print("Not my ack")
+        if status == 3:
+            print("request id doesn't match")
+        return s, bytearray()
+    print("get success")
+    return 0, s
 
 def put_BtArray(id, keyInfo):
     shmArray = libPyCpp.kvs_ShmPtr_btArray(keyInfo)
     for i in range(int(keyInfo)):
         shmArray[i] = 0x03
-    libPyCpp.kvs_Put(id, keyInfo)
-    a = libPyCpp.kvs_free(shmArray)
-    return
+    status = libPyCpp.kvs_Put(id, keyInfo)
+    if status == 0:
+        print("put success")
+    if status == 1:
+        print("Ack error")
+    if status == 2:
+        print("Not my ack")
+    if status == 3:
+        print("request id doesn't match")
+    libPyCpp.kvs_free(shmArray)
+    return status
 
+"""
+get function:
+    return (err, results)
+err: 0 -- succ
+     1 -- ack error
+     2 -- not my ack
+     3 -- request id doesn't match
+"""
 def get_BtArray(id, keyInfo):
     s = libPyCpp.kvs_GetBt(id, keyInfo)
-    return s
+    if isinstance(s,int):
+        if status == 1:
+            print("Ack error")
+        if status == 2:
+            print("Not my ack")
+        if status == 3:
+            print("request id doesn't match")
+        return s, bytearray()
+    print("get success")
+    return 0, s
 
 """
 put function:
@@ -52,22 +87,15 @@ def get(id, keyInfo, dataStruc):
 
 # put(1, "256", 0)
 # rs = get(1, "256", 0)
-print("1kb")
-put(1, "1000", 1)
-start = time.time()
-rs2 = get(1, "1000", 1)
-end = time.time()
-print("1 KB get using  ", end-start)
-print("10Mb")
-put(1, "10000000", 1)
-start = time.time()
-rs1 = get(1, "10000000", 1)
-end = time.time()
-print("10 MB get using ", end-start)
+status = put(1, "45", 1)
+status, rs2 = get(1, "45", 1)
+print(rs2)
+status = put(2, "45", 1)
+status, rs3 = get(2, "45", 1)
+libPyCpp.kvs_quit()
 
 """
 require explicitly free bytearray object. 
 """
 a = libPyCpp.kvs_free(rs2)
-a = libPyCpp.kvs_free(rs1)
-
+a = libPyCpp.kvs_free(rs3)


### PR DESCRIPTION
Support reconnect and disconnect one time. But when the client finishes in python, need to call quit explicitly to disconnect all the channel for each client.

Support return error to python client rather than a lot of Py_None